### PR TITLE
Fix U1 interleave parity drift

### DIFF
--- a/python/sglang/multimodal_gen/runtime/pipelines_core/stages/model_specific_stages/sensenova_u1/pixel_flow.py
+++ b/python/sglang/multimodal_gen/runtime/pipelines_core/stages/model_specific_stages/sensenova_u1/pixel_flow.py
@@ -38,6 +38,7 @@ _U1_EDIT_IMG_CONDITION_ROLE = "u1_edit_img_condition"
 _U1_EDIT_UNCONDITION_ROLE = "u1_edit_uncondition"
 _U1_IMAGENET_MEAN = (0.485, 0.456, 0.406)
 _U1_IMAGENET_STD = (0.229, 0.224, 0.225)
+_U1_PIXEL_FLOW_GENERATOR_KEY = "_sensenova_u1_pixel_flow_generator"
 
 
 @dataclass(frozen=True, slots=True)
@@ -118,7 +119,7 @@ class SenseNovaU1PixelFlowStage(DenoisingStage):
         ) = _resolve_u1_contexts(context_ops=context_ops, batch=batch)
         prepared = self._prepare(
             model=model,
-            context_metadata=dict(context_ops.metadata),
+            context_metadata=context_ops.metadata,
             batch=batch,
             u1_context=u1_context,
             cfg_img_condition_u1_context=cfg_img_condition_u1_context,
@@ -188,7 +189,11 @@ class SenseNovaU1PixelFlowStage(DenoisingStage):
 
         device = _model_device(model)
         seed = _batch_seed(batch)
-        generator = _new_torch_generator(seed=seed, device=device)
+        generator = _get_or_create_context_generator(
+            context_metadata,
+            seed=seed,
+            device=device,
+        )
         noise_scale = float(_noise_scale_for_image(model, grid_h=grid_h, grid_w=grid_w))
         dtype = _model_dtype(model)
         image_prediction = noise_scale * torch.randn(
@@ -633,9 +638,14 @@ def _require_context(
     message: str,
     condition_path_role: str | None = None,
 ) -> _SenseNovaU1GenerationContext:
-    position_count = context_ops.get_position_count(
-        condition_path_role=condition_path_role
+    position_count = _u1_condition_path_logical_position(
+        context_ops,
+        condition_path_role,
     )
+    if position_count is None:
+        position_count = context_ops.get_position_count(
+            condition_path_role=condition_path_role
+        )
     if position_count is None:
         suffix = (
             f" condition path {condition_path_role}"
@@ -648,6 +658,27 @@ def _require_context(
         condition_path_role=condition_path_role,
         position_count=int(position_count),
     )
+
+
+def _u1_condition_path_logical_position(
+    context_ops: ContextOps,
+    condition_path_role: str | None,
+) -> int | None:
+    if condition_path_role is None:
+        return None
+    runtime = getattr(getattr(context_ops, "session_adapter", None), "runtime", None)
+    session_id = getattr(context_ops, "session_id", None)
+    if runtime is None or session_id is None:
+        return None
+    model_state = runtime.get_condition_path_model_state(
+        session_id,
+        condition_path_role,
+    )
+    u1_state = (model_state or {}).get("u1") or {}
+    position = u1_state.get("generation_position_start")
+    if position is None:
+        return None
+    return int(position)
 
 
 def _require_context_ops(batch: Req) -> ColocatedContextOps:
@@ -824,6 +855,31 @@ def _new_torch_generator(*, seed: int, device: Any) -> Any:
     import torch
 
     return torch.Generator(device=device).manual_seed(int(seed))
+
+
+def _get_or_create_context_generator(
+    metadata: dict[str, Any],
+    *,
+    seed: int,
+    device: Any,
+) -> Any:
+    state = metadata.get(_U1_PIXEL_FLOW_GENERATOR_KEY)
+    device_repr = str(device)
+    if (
+        isinstance(state, dict)
+        and state.get("seed") == int(seed)
+        and state.get("device") == device_repr
+        and state.get("generator") is not None
+    ):
+        return state["generator"]
+
+    generator = _new_torch_generator(seed=seed, device=device)
+    metadata[_U1_PIXEL_FLOW_GENERATOR_KEY] = {
+        "seed": int(seed),
+        "device": device_repr,
+        "generator": generator,
+    }
+    return generator
 
 
 def _batch_seed(batch: Any) -> int:

--- a/python/sglang/omni/model_adapters/sensenova_u1/context.py
+++ b/python/sglang/omni/model_adapters/sensenova_u1/context.py
@@ -228,10 +228,8 @@ U1_INTERLEAVE_SYSTEM_MESSAGE = (
     "without reasoning. Do not use tags like <image1>, <image2>; present any "
     "images naturally alongside the text.\n\n"
     "After the think block, always provide a concise, user-facing final answer. "
-    "The final answer must not include hidden reasoning, planning steps, numbered "
-    'analysis, explicit image prompts, or phrases like "I will". The answer may '
-    "include text, images, or both. Match the user's language in both reasoning "
-    "and the final answer."
+    "The answer may include text, images, or both. Match the user's language in "
+    "both reasoning and the final answer."
 )
 
 
@@ -1374,6 +1372,7 @@ def _u1_generated_image_commit_metadata(
     )
     return {
         "u1": u1_segment.to_dict(),
+        "omni_srt_position_count": generation_position_start,
         "omni_model_state_updates": state_patch.to_model_state_updates(),
     }
 


### PR DESCRIPTION
## Motivation

This PR fixes the remaining SenseNova U1 interleave drift we found while comparing SGLang against the official implementation on the multi-round text + image tutorial case.

The goal is not bitwise parity with the official HF/SDPA path. The target is to remove logic mismatches in the U1 interleave runtime so that SGLang follows the same text/image flow and only diverges at tiny numerical tie / near-tie points.

## Modifications

- Preserve the SenseNova U1 pixel-flow random generator in shared context metadata instead of recreating it for each generation prepare step.
- Use the U1 logical `generation_position_start` for condition-path position count when available, with fallback to the existing context position count.
- Carry `generation_position_start` into generated-image commit metadata as `omni_srt_position_count` so later condition paths can recover the logical U1 position.
- Relax the U1 interleave system prompt so the final response is not over-constrained away from the official interleave behavior.

## Accuracy Tests

Validated on the official SenseNova U1 tomato-and-egg interleave tutorial case:

- Official repo: `/data/SenseNova-U1-official`
- SGLang replay repo: `/data/sglang_u1_parity_replay`
- Model: `/data/models/sensenova/SenseNova-U1-8B-MoT`
- Runtime: H100, single GPU, `torch_native` attention parity run
- Prompt: `I want to learn how to cook tomato and egg stir-fry. Please give me a beginner-friendly illustrated tutorial.`
- Output mode: multi-round interleave, 6 generated images

Observed result:

- SGLang and official U text generation match exactly through the first 63 generated tokens.
- The first text divergence happens at a tiny-margin / tie point:
  - official top choice: `being`
  - competing token: `not`
  - official raw logit gap: `0.125`
  - SGLang top-k still ranks `being` at the top, but `being` and `not` become equal after the SGLang numerical path, so sampling chooses `not`.
- Enabling `--enable-fp32-lm-head` does not fix this; it actually diverges earlier at an official `being` / `becoming` tie.

Conclusion: after this PR, the remaining mismatch is numerical drift amplified by autoregressive decoding, not a prompt / position / commit / G-flow logic bug.

## Benchmarking and Profiling

No performance benchmark was run. The changes are limited to U1 interleave metadata/position handling and RNG continuity; they are not intended to change throughput.

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).
- [ ] Work with maintainers to merge your PR. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process)
